### PR TITLE
Add -S command line option to use a releasestream image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ structopt = "0.2"
 directories = "1.0"
 anyhow = "1.0"
 lazy_static = "1.2.0"
+reqwest = { version = "0.10", features = ["blocking", "json"] }
 tempfile = "3.0.7"
-serde = "1.0.78"
-serde_derive = "1.0.78"
+serde = "1.0.104"
+serde_derive = "1.0.104"
 serde_yaml = "0.8"
 serde_json = "1.0"
 tabwriter = "1.1.0"
+url = "2.1.1"
 
 [[bin]]
 name = "xokdinst"


### PR DESCRIPTION
Uses a release stream name to fetch the latest release image.

```
xokdinst launch -S 4.4.0-0.nightly -p libvirt test1
```

Also adds TF_VAR injection into the installer environment for overrides.